### PR TITLE
fix: Remove the `MessageInput` union type. 

### DIFF
--- a/.semversioner/next-release/patch-20241124134858541882.json
+++ b/.semversioner/next-release/patch-20241124134858541882.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "Removed MessageInput type; Fixed the type annotation for call."
+}

--- a/src/omnillm/base.py
+++ b/src/omnillm/base.py
@@ -87,7 +87,7 @@ class BaseClient(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def organize_messages(self, messages: list[BaseMessage]):
+    def organize_messages(self, messages):
         raise NotImplementedError
 
     def _validate_message_sequence(self, messages: list[BaseMessage]):

--- a/src/omnillm/base.py
+++ b/src/omnillm/base.py
@@ -5,10 +5,9 @@
 import os
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Generic, TypeVar, Union
+from typing import Generic, TypeVar
 
 from dotenv import load_dotenv
-from PIL import Image
 
 load_dotenv()
 
@@ -43,9 +42,6 @@ class ImageDetail(Enum):
 class ServiceType(Enum):
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
-
-
-MessageInput = Union[str, dict[str, Any], "BaseMessage", Image.Image]
 
 
 class BaseMessage(Generic[T]):

--- a/src/omnillm/message.py
+++ b/src/omnillm/message.py
@@ -4,11 +4,11 @@
 
 import base64
 import io
-from typing import NotRequired, TypedDict, Union
+from typing import Any, NotRequired, TypedDict, Union, overload
 
 from PIL import Image
 
-from .base import BaseMessage, ContentType, ImageDetail, ImageFormat, MessageInput, Role
+from .base import BaseMessage, ContentType, ImageDetail, ImageFormat, Role
 from .utils import is_valid_image_url
 
 MessageDict = TypedDict(
@@ -55,7 +55,15 @@ class ImageMessage(BaseMessage[Image.Image]):
         return self._detail
 
 
-def convert_to_message(msg: MessageInput) -> BaseMessage:
+@overload
+def convert_to_message(msg: str) -> TextMessage: ...
+@overload
+def convert_to_message(msg: Image.Image) -> ImageMessage: ...
+@overload
+def convert_to_message(msg: dict[str, Any]) -> BaseMessage: ...
+
+
+def convert_to_message(msg: str | Image.Image | dict[str, Any]) -> BaseMessage:
     if isinstance(msg, str):
         return TextMessage(content=msg, role=Role.USER)
 

--- a/src/omnillm/openai.py
+++ b/src/omnillm/openai.py
@@ -2,15 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Callable, Sequence, TypeVar, cast
+from typing import Any, Callable, Sequence, TypeVar, cast, overload
 
 from openai import AsyncOpenAI, AuthenticationError, OpenAI, PermissionDeniedError
 from openai.types.chat import ChatCompletion
+from PIL import Image
 
 from .base import (
     BaseClient,
     BaseMessage,
-    MessageInput,
     Role,
     ServiceType,
 )
@@ -60,7 +60,7 @@ class OpenAIClient(BaseClient):
         return {"role": "user", "content": contents.copy()}
 
     def organize_messages(
-        self, messages: Sequence[MessageInput]
+        self, messages: Sequence[str | dict[str, Any] | Image.Image]
     ) -> list[dict[str, Any]]:
         processed_messages = [
             msg if isinstance(msg, BaseMessage) else convert_to_message(msg)
@@ -105,7 +105,7 @@ class OpenAIClient(BaseClient):
 
     def _prepare_request(
         self,
-        messages: list[MessageInput],
+        messages: Sequence[str | dict[str, Any] | Image.Image],
         model: str,
         temperature: float,
         **kwargs: Any,
@@ -119,10 +119,70 @@ class OpenAIClient(BaseClient):
         }
         return prompt, params
 
+    @overload
+    def call(
+        self,
+        messages: Sequence[str],
+        callback: None = None,
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> str: ...
+    @overload
+    def call(
+        self,
+        messages: Sequence[str],
+        callback: Callable[[str], T],
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> T: ...
+    @overload
+    def call(
+        self,
+        messages: Sequence[dict[str, Any]],
+        callback: None = None,
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> str: ...
+    @overload
+    def call(
+        self,
+        messages: Sequence[dict[str, Any]],
+        callback: Callable[[str], T],
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> T: ...
+    @overload
+    def call(
+        self,
+        messages: Sequence[Image.Image],
+        callback: None = None,
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> str: ...
+    @overload
+    def call(
+        self,
+        messages: Sequence[Image.Image],
+        callback: Callable[[str], T],
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> T: ...
     @retry(max_attempts=3, skip_exceptions=(AuthenticationError, PermissionDeniedError))
     def call(
         self,
-        messages: list[MessageInput],
+        messages: Sequence[str | dict[str, Any] | Image.Image],
         model: str = "gpt-4o-mini",
         temperature: float = 0.5,
         callback: Callable[[str], T] | None = None,
@@ -139,12 +199,72 @@ class OpenAIClient(BaseClient):
             return callback(resp_obj)
         return resp_obj
 
+    @overload
+    def async_call(
+        self,
+        messages: Sequence[str],
+        callback: None = None,
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> str: ...
+    @overload
+    def async_call(
+        self,
+        messages: Sequence[str],
+        callback: Callable[[str], T],
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> T: ...
+    @overload
+    def async_call(
+        self,
+        messages: Sequence[dict[str, Any]],
+        callback: None = None,
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> str: ...
+    @overload
+    def async_call(
+        self,
+        messages: Sequence[dict[str, Any]],
+        callback: Callable[[str], T],
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> T: ...
+    @overload
+    def async_call(
+        self,
+        messages: Sequence[Image.Image],
+        callback: None = None,
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> str: ...
+    @overload
+    def async_call(
+        self,
+        messages: Sequence[Image.Image],
+        callback: Callable[[str], T],
+        *,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        **kwargs: Any,
+    ) -> T: ...
     @async_retry(
         max_attempts=3, skip_exceptions=(AuthenticationError, PermissionDeniedError)
     )
     async def async_call(
         self,
-        messages: list[MessageInput],
+        messages: Sequence[str | dict[str, Any] | Image.Image],
         model: str = "gpt-4o-mini",
         temperature: float = 0.5,
         callback: Callable[[str], T] | None = None,


### PR DESCRIPTION
This pull request includes several changes to the `omnillm` package, focusing on type annotations and method overloading. The most important changes include the removal of the `MessageInput` type, the addition of type annotations for the `call` method, and the introduction of method overloads for handling different message types.

### Type Annotations and Method Overloading:

* Removed `MessageInput` type and updated type annotations for methods to handle `str`, `dict[str, Any]`, and `Image.Image` types directly. (`src/omnillm/anthropic.py`, `src/omnillm/openai.py`, `src/omnillm/base.py`, `src/omnillm/message.py`) [[1]](diffhunk://#diff-3e4e78bfa9b392b75b675076149aacdd24ee47acb78852d073a8f7bd4e1cd2d6L5-L17) [[2]](diffhunk://#diff-3e4e78bfa9b392b75b675076149aacdd24ee47acb78852d073a8f7bd4e1cd2d6L78-R78) [[3]](diffhunk://#diff-3e4e78bfa9b392b75b675076149aacdd24ee47acb78852d073a8f7bd4e1cd2d6L119-R119) [[4]](diffhunk://#diff-3e4e78bfa9b392b75b675076149aacdd24ee47acb78852d073a8f7bd4e1cd2d6R141-R204) [[5]](diffhunk://#diff-3e4e78bfa9b392b75b675076149aacdd24ee47acb78852d073a8f7bd4e1cd2d6R218-R283) [[6]](diffhunk://#diff-407e049ed03a944053135f0328cdd4d2501fcc6c3d9f1292cb32691a75358203L8-L11) [[7]](diffhunk://#diff-407e049ed03a944053135f0328cdd4d2501fcc6c3d9f1292cb32691a75358203L48-L50) [[8]](diffhunk://#diff-99bc3eef180cb61f09ab7914320baa88c56f162fc264bc4c40a0543e4b2090a0L7-R11) [[9]](diffhunk://#diff-99bc3eef180cb61f09ab7914320baa88c56f162fc264bc4c40a0543e4b2090a0L58-R66) [[10]](diffhunk://#diff-166407b4aedd36e9172ffc3e57c6d61065aa12072f3a642747f21114e5918432L5-L13) [[11]](diffhunk://#diff-166407b4aedd36e9172ffc3e57c6d61065aa12072f3a642747f21114e5918432L63-R63) [[12]](diffhunk://#diff-166407b4aedd36e9172ffc3e57c6d61065aa12072f3a642747f21114e5918432L108-R108) [[13]](diffhunk://#diff-166407b4aedd36e9172ffc3e57c6d61065aa12072f3a642747f21114e5918432R122-R185) [[14]](diffhunk://#diff-166407b4aedd36e9172ffc3e57c6d61065aa12072f3a642747f21114e5918432R202-R267)

* Added method overloads for the `call` and `async_call` methods to handle different message types (`str`, `dict[str, Any]`, and `Image.Image`). (`src/omnillm/anthropic.py`, `src/omnillm/openai.py`) [[1]](diffhunk://#diff-3e4e78bfa9b392b75b675076149aacdd24ee47acb78852d073a8f7bd4e1cd2d6R141-R204) [[2]](diffhunk://#diff-3e4e78bfa9b392b75b675076149aacdd24ee47acb78852d073a8f7bd4e1cd2d6R218-R283) [[3]](diffhunk://#diff-166407b4aedd36e9172ffc3e57c6d61065aa12072f3a642747f21114e5918432R122-R185) [[4]](diffhunk://#diff-166407b4aedd36e9172ffc3e57c6d61065aa12072f3a642747f21114e5918432R202-R267)

### Patch Description:

* Added a patch description indicating the removal of `MessageInput` type and fixing type annotations for `call` method. (`.semversioner/next-release/patch-20241124134858541882.json`)